### PR TITLE
Add getContextsByCanvasId()

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,17 @@ export default {
 
     return this.contexts[idx];
   },
+  getContextsByCanvasId: function(id, type) {
+    let contexts;
+    if (type === 'webgl') {
+      contexts = this.webglContexts;
+    } else if (type === '2d') {
+      contexts = this.canvas2dContexts;
+    } else {
+      contexts = this.contexts;
+    }
+    return contexts.filter(context => id === context.canvas.id);
+  },
   isWebGLContext: function(ctx) {
     return (ctx instanceof WebGLRenderingContext) || (window.WebGL2RenderingContext && (ctx instanceof WebGL2RenderingContext));
   },


### PR DESCRIPTION
This PR adds `.getContextsByCanvasId()` method.

This is from https://github.com/MozillaReality/webgfx-tests/issues/98. I want to add a way to find context by canvas element id to `webfx-tests`.